### PR TITLE
use pinpointed handling of non-serializable data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Next (tbd)
 
 * `#16 <https://github.com/pytest-dev/pytest-reportlog/issues/15>`_: switch recommended file extension to `jsonl <https://jsonlines.org/>`__.
 * `#17 <https://github.com/pytest-dev/pytest-reportlog/issues/17>`_: add compression support for ``.bz2``/``.gz``/``.xz`` log file extensions.
+* `#12 <https://github.com/pytest-dev/pytest-reportlog/issues/12>`_: handle unserializable objects with a pinpointed marker
 
 
 0.3.0 (2023-04-26)

--- a/src/pytest_reportlog/plugin.py
+++ b/src/pytest_reportlog/plugin.py
@@ -63,11 +63,7 @@ class ReportLogPlugin:
             self._file = None
 
     def _write_json_data(self, data):
-        try:
-            json_data = json.dumps(data)
-        except TypeError:
-            data = cleanup_unserializable(data)
-            json_data = json.dumps(data)
+        json_data = json.dumps(data, default=unserializable_to_marked_str)
         self._file.write(json_data + "\n")
         self._file.flush()
 
@@ -92,7 +88,7 @@ class ReportLogPlugin:
             ),
             "filename": warning_message.filename,
             "lineno": warning_message.lineno,
-            "message": warning_message.message,
+            "message": str(warning_message.message),
         }
         extra_data = {
             "$report_type": "WarningMessage",
@@ -112,13 +108,6 @@ class ReportLogPlugin:
         terminalreporter.write_sep("-", f"generated report log file: {self._log_path}")
 
 
-def cleanup_unserializable(d: Dict[str, Any]) -> Dict[str, Any]:
-    """Return new dict with entries that are not json serializable by their str()."""
-    result = {}
-    for k, v in d.items():
-        try:
-            json.dumps({k: v})
-        except TypeError:
-            v = str(v)
-        result[k] = v
-    return result
+def unserializable_to_marked_str(obj: object) -> Dict[str, str]:
+    """for a object that json can not serialize. return {"$no-json": str(obj)}"""
+    return { "$no-json": str(obj)}


### PR DESCRIPTION
fixes #12

the caveat is that now we sometimes have magic json objects in the depth of a message to fix the details

this also exposed a bug in warning record message handling that was hidden by the broad str magic