### PR TITLE
add an option to avoid capturing logs for passed tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Next (tbd)
 
 * `#15 <https://github.com/pytest-dev/pytest-reportlog/issues/15>`_: switch recommended file extension to `jsonl <https://jsonlines.org/>`__.
 * `#17 <https://github.com/pytest-dev/pytest-reportlog/issues/17>`_: add compression support for ``.bz2``/``.gz``/``.xz`` log file extensions.
+* `#39 <https://github.com/pytest-dev/pytest-reportlog/issues/39>`_: allow not capturing logs for passed tests
 
 
 0.3.0 (2023-04-26)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Next (tbd)
 
 * `#15 <https://github.com/pytest-dev/pytest-reportlog/issues/15>`_: switch recommended file extension to `jsonl <https://jsonlines.org/>`__.
 * `#17 <https://github.com/pytest-dev/pytest-reportlog/issues/17>`_: add compression support for ``.bz2``/``.gz``/``.xz`` log file extensions.
-* `#39 <https://github.com/pytest-dev/pytest-reportlog/issues/39>`_: allow not capturing logs for passed tests
+* `#39 <https://github.com/pytest-dev/pytest-reportlog/issues/39>`_: new ``--report-log-exclude-logs-on-passed-tests`` option allows not capturing logs of passing tests.
 
 
 0.3.0 (2023-04-26)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Next (tbd)
 -------------------
 
-* `#16 <https://github.com/pytest-dev/pytest-reportlog/issues/15>`_: switch recommended file extension to `jsonl <https://jsonlines.org/>`__.
+* `#15 <https://github.com/pytest-dev/pytest-reportlog/issues/15>`_: switch recommended file extension to `jsonl <https://jsonlines.org/>`__.
 * `#17 <https://github.com/pytest-dev/pytest-reportlog/issues/17>`_: add compression support for ``.bz2``/``.gz``/``.xz`` log file extensions.
 
 

--- a/tests/test_reportlog.py
+++ b/tests/test_reportlog.py
@@ -136,11 +136,10 @@ def test_exclude_logs_for_passing_tests(testdir, tmp_path, exclude):
 
     log = fn.read_text("UTF-8")
     if exclude:
-        assert log.find(passing_log_entry) < 0
-        assert log.find(failing_log_entry) >= 0
+        assert passing_log_entry not in log        
     else:
-        assert log.find(passing_log_entry) >= 0
-        assert log.find(failing_log_entry) >= 0
+        assert passing_log_entry in log
+    assert failing_log_entry in log
 
 
 def test_xdist_integration(testdir, tmp_path):

--- a/tests/test_reportlog.py
+++ b/tests/test_reportlog.py
@@ -136,7 +136,7 @@ def test_exclude_logs_for_passing_tests(testdir, tmp_path, exclude):
 
     log = fn.read_text("UTF-8")
     if exclude:
-        assert passing_log_entry not in log        
+        assert passing_log_entry not in log
     else:
         assert passing_log_entry in log
     assert failing_log_entry in log

--- a/tests/test_reportlog.py
+++ b/tests/test_reportlog.py
@@ -105,6 +105,44 @@ def test_basics(testdir, tmp_path, pytestconfig):
         assert isinstance(rep, BaseReport)
 
 
+@pytest.mark.parametrize(
+    "exclude", [True, False], ids=["exclude on pass", "include logs on pass"]
+)
+def test_exclude_logs_for_passing_tests(testdir, tmp_path, exclude):
+    passing_log_entry = "THIS TEST PASSED!"
+    failing_log_entry = "THIS TEST FAILED!"
+    testdir.makepyfile(
+        f"""
+        import logging
+
+        logger = logging.getLogger(__name__)
+
+        def test_ok():
+            logger.warning("{passing_log_entry}")
+
+        def test_fail():
+            logger.warning("{failing_log_entry}")
+            assert 0
+        """
+    )
+    fn = tmp_path / "result.log"
+    if exclude:
+        result = testdir.runpytest(
+            f"--report-log={fn}", "--report-log-exclude-logs-on-passed-tests"
+        )
+    else:
+        result = testdir.runpytest(f"--report-log={fn}")
+    result.stdout.fnmatch_lines("*1 failed, 1 passed*")
+
+    log = fn.read_text("UTF-8")
+    if exclude:
+        assert log.find(passing_log_entry) < 0
+        assert log.find(failing_log_entry) >= 0
+    else:
+        assert log.find(passing_log_entry) >= 0
+        assert log.find(failing_log_entry) >= 0
+
+
 def test_xdist_integration(testdir, tmp_path):
     pytest.importorskip("xdist")
     testdir.makepyfile(


### PR DESCRIPTION
Captured logs can be a non-trivial amount of data. This is analogus to the similar option for the Junit XML plugin

As written this defaults to *not* capturing the logs on passes. Which would be a breaking change. I think that makes sense as to me it seems like a more reasonable default and it's consistent with how the junit XML plugin behaves. I can invert that logic if required though.

Fix #39 